### PR TITLE
Enhance video components with slow zoom-in effect

### DIFF
--- a/src/components/videos/LandscapeVideo.tsx
+++ b/src/components/videos/LandscapeVideo.tsx
@@ -5,6 +5,8 @@ import {
   useVideoConfig,
   Audio,
   OffthreadVideo,
+  interpolate,
+  Loop,
 } from "remotion";
 import { z } from "zod";
 import "./fonts.css";
@@ -81,13 +83,39 @@ export const LandscapeVideo: React.FC<z.infer<typeof shortVideoSchema>> = ({
           durationInFrames += Math.round((config.paddingBack / 1000) * fps);
         }
 
+        // Local frame inside this scene to reset animations per scene
+        const localFrame = Math.max(
+          0,
+          Math.min(frame - startFrame, durationInFrames),
+        );
+
+        // Slow zoom-in (Ken Burns) for the background video across the scene
+        const scale = interpolate(
+          localFrame,
+          [0, Math.max(1, Math.round(durationInFrames * 0.6))],
+          [1, 1.12],
+          { extrapolateLeft: "clamp", extrapolateRight: "clamp" },
+        );
+
         return (
           <Sequence
             from={startFrame}
             durationInFrames={durationInFrames}
             key={`scene-${i}`}
           >
-            <OffthreadVideo src={video} muted />
+            <Loop durationInFrames={durationInFrames}>
+              <OffthreadVideo
+                src={video}
+                muted
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  objectFit: "cover",
+                  transform: `scale(${scale})`,
+                  transformOrigin: "50% 50%",
+                }}
+              />
+            </Loop>
             <Audio src={audio.url} />
             {/* SFX removed */}
             

--- a/src/components/videos/PortraitVideo.tsx
+++ b/src/components/videos/PortraitVideo.tsx
@@ -5,6 +5,8 @@ import {
   useVideoConfig,
   Audio,
   OffthreadVideo,
+  interpolate,
+  Loop,
 } from "remotion";
 import { z } from "zod";
 import "./fonts.css";
@@ -81,13 +83,39 @@ export const PortraitVideo: React.FC<z.infer<typeof shortVideoSchema>> = ({
           durationInFrames += Math.round((config.paddingBack / 1000) * fps);
         }
 
+        // Local frame inside this scene to reset animations per scene
+        const localFrame = Math.max(
+          0,
+          Math.min(frame - startFrame, durationInFrames),
+        );
+
+        // Slow zoom-in (Ken Burns) for the background video across the scene
+        const scale = interpolate(
+          localFrame,
+          [0, Math.max(1, Math.round(durationInFrames * 0.6))],
+          [1, 1.12],
+          { extrapolateLeft: "clamp", extrapolateRight: "clamp" },
+        );
+
         return (
           <Sequence
             from={startFrame}
             durationInFrames={durationInFrames}
             key={`scene-${i}`}
           >
-            <OffthreadVideo src={video} muted />
+            <Loop durationInFrames={durationInFrames}>
+              <OffthreadVideo
+                src={video}
+                muted
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  objectFit: "cover",
+                  transform: `scale(${scale})`,
+                  transformOrigin: "50% 50%",
+                }}
+              />
+            </Loop>
             <Audio src={audio.url} />
             {/* SFX removed */}
             


### PR DESCRIPTION
- Added interpolation for a slow zoom-in (Ken Burns effect) in LandscapeVideo and PortraitVideo components.
- Wrapped OffthreadVideo in a Loop to maintain the zoom effect throughout the scene duration.
- Improved styling for OffthreadVideo to ensure proper scaling and object fit.